### PR TITLE
disable guard clause and numeric predicate

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -95,6 +95,10 @@ Style/EmptyMethod:
   EnforcedStyle: expanded
 Style/NumericLiterals:
   Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Style/GuardClause:
+  Enabled: false
 
 ##### Linting Cops #####
 Lint/AssignmentInCondition:


### PR DESCRIPTION
* Disable [Numeric Predicate](https://rubocop.readthedocs.io/en/latest/cops_style/#stylenumericpredicate). IMO the predicate methods are nice, but not I don't think they should be a requirement.
* Disable [Guard Clause](https://rubocop.readthedocs.io/en/latest/cops_style/#styleguardclause). I don't think we necessarily need to default to shorthands or "clever" solutions, when longform versions are perfectly acceptable and often provide clarity
