### PR TITLE
disable multiline block chain cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -72,7 +72,7 @@ Layout/TrailingBlankLines:
   EnforcedStyle: final_newline
 Layout/TrailingWhitespace:
   Enabled: true
-  AllowInHeredoc: falsef
+  AllowInHeredoc: false
 
 ###### Style Cops #####
 Style/StringLiterals:
@@ -95,6 +95,8 @@ Style/EmptyMethod:
   EnforcedStyle: expanded
 Style/NumericLiterals:
   Enabled: false
+Style/BlockDelimiters:
+  EnforcedStyle: braces_for_chaining
 
 ##### Linting Cops #####
 Lint/AssignmentInCondition:


### PR DESCRIPTION
prefer curly braces on blocks with return values
```rb
# good
expect {
  visit root_path
  click "link title"
}.to raise_error

# bad
expect do
  visit root_path
  click "link title"
end.to raise_error
```