### PR TITLE
enforce assignment inside condition

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -95,6 +95,8 @@ Style/EmptyMethod:
   EnforcedStyle: expanded
 Style/NumericLiterals:
   Enabled: false
+Style/ConditionalAssignment:
+  Enforced: assign_inside_condition
 
 ##### Linting Cops #####
 Lint/AssignmentInCondition:


### PR DESCRIPTION
Preferred style is to have variable assignment inside conditional rather than outside.

[Documentation](https://rubocop.readthedocs.io/en/latest/cops_style/#styleconditionalassignment)